### PR TITLE
feat: upgrade Bedrock model to Claude Opus 4.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Pure Confluent Cloud infrastructure — no datagen, no CDC connector:
 - Topics (all 1 partition): `mortgage_applications`, `payment_history`, `incomplete_mortgage_applications` (DLQ), `PROD.public.applicant_credit_score` (pre-created with `cleanup.policy=compact`)
 - AVRO schemas with data quality rules (CEL validation: payslip URI must match `^s3://riverbank-payslip-bucket/[a-zA-Z0-9._/-]+$` → DLQ routing on failure)
 - `alter_mortgage_applications` Flink statement — adds WATERMARK on `application_ts` for temporal join support
-- Bedrock connection + LLM model (`llm_textgen_model` — Claude 3.7 Sonnet, 50K max tokens)
+- Bedrock connection + LLM model (`llm_textgen_model` — Claude Opus 4.5, 50K max tokens)
 - MCP connection (configurable endpoint + transport type) for external tool access
 - Webapp Docker container (`mortgage-webapp`) — built locally from `webapp/Dockerfile`, port 5001→5000
 - Outputs credentials for datagen and CDC connector modules

--- a/SETUP-SELF-SERVE.md
+++ b/SETUP-SELF-SERVE.md
@@ -63,13 +63,13 @@ Before starting, make sure you have:
 > Request model access before you begin the Terraform steps below. Approval can take a few minutes, and starting early avoids delays later.
 
 <details>
-<summary>Enable Claude 3.7 Sonnet in Amazon Bedrock</summary>
+<summary>Enable Claude Opus 4.5 in Amazon Bedrock</summary>
 
-To enable Claude 3.7 Sonnet in your AWS account via Amazon Bedrock:
+To enable Claude Opus 4.5 in your AWS account via Amazon Bedrock:
 
 1. Open the Amazon Bedrock Console (`https://console.aws.amazon.com/bedrock/home?/overview`) and ensure you are in the same region you will deploy.
 2. In the left sidebar, under Bedrock configuration, click Model access.
-3. Locate Claude 3.7 Sonnet in the list of available models.
+3. Locate Claude Opus 4.5 in the list of available models.
 4. Click Available to request, then select Request model access.
 5. In the request wizard, click Next and follow the prompts to complete the request.
 

--- a/terraform/modules/base/main.tf
+++ b/terraform/modules/base/main.tf
@@ -304,38 +304,6 @@ resource "confluent_flink_statement" "alter_mortgage_applications" {
 # ------------------------------------------------------
 
 # Drop existing MCP connection to allow recreation
-resource "confluent_flink_statement" "mcp_connection_drop" {
-
-  organization {
-    id = data.confluent_organization.confluent_org.id
-  }
-  environment {
-    id = confluent_environment.staging.id
-  }
-  compute_pool {
-    id = confluent_flink_compute_pool.flinkpool-main.id
-  }
-  principal {
-    id = confluent_service_account.app-manager.id
-  }
-  rest_endpoint = data.confluent_flink_region.demo_flink_region.rest_endpoint
-  credentials {
-    key    = confluent_api_key.app-manager-flink-api-key.id
-    secret = confluent_api_key.app-manager-flink-api-key.secret
-  }
-
-  statement_name = "mcp-connection-drop"
-
-  statement = <<-EOT
-    DROP CONNECTION IF EXISTS `${confluent_environment.staging.display_name}`.`${confluent_kafka_cluster.standard.display_name}`.`mcp_connection`;
-  EOT
-
-  properties = {
-    "sql.current-catalog"  = confluent_environment.staging.display_name
-    "sql.current-database" = confluent_kafka_cluster.standard.display_name
-  }
-}
-
 resource "confluent_flink_statement" "mcp_connection" {
 
   organization {
@@ -371,10 +339,6 @@ resource "confluent_flink_statement" "mcp_connection" {
     "sql.current-catalog"  = confluent_environment.staging.display_name
     "sql.current-database" = confluent_kafka_cluster.standard.display_name
   }
-
-  depends_on = [
-    confluent_flink_statement.mcp_connection_drop
-  ]
 
   lifecycle {
     ignore_changes = [statement]
@@ -417,7 +381,7 @@ resource "confluent_flink_connection" "bedrock_connection" {
 
   display_name   = "llm-textgen-connection"
   type           = "BEDROCK"
-  endpoint       = "https://bedrock-runtime.${var.cloud_region}.amazonaws.com/model/${local.model_prefix}.anthropic.claude-3-7-sonnet-20250219-v1:0/invoke"
+  endpoint       = "https://bedrock-runtime.${var.cloud_region}.amazonaws.com/model/${local.model_prefix}.anthropic.claude-opus-4-5-20251101-v1:0/invoke"
   aws_access_key = var.bedrock_access_key
   aws_secret_key = var.bedrock_secret_key
 


### PR DESCRIPTION
## Summary
- Switch the `llm-textgen-connection` Bedrock endpoint from `claude-3-7-sonnet-20250219-v1:0` (no longer available on Bedrock) to `claude-opus-4-5-20251101-v1:0`
- Update `SETUP-SELF-SERVE.md` and `CLAUDE.md` to reference the new model
- Drop the `mcp_connection_drop` helper Flink statement (and its `depends_on` reference) — no longer needed

Affects all three deployment modes (workshop, self-serve, demo) since the change lives in `modules/base/`.

## Test plan
- [x] Workshop mode deploys cleanly (`terraform apply` from `terraform/workshop/` — 31 resources added)
- [x] Bedrock connection created successfully with the new endpoint
- [x] CDC connector + Flink statements provision without error
- [ ] Self-serve mode deploy verified
- [ ] Demo mode deploy verified
- [ ] End-to-end mortgage app submission flows through risk + decision agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)