### PR TITLE
fix: strip markdown code fences from agent JSON responses

### DIFF
--- a/lab2/lab2-README.md
+++ b/lab2/lab2-README.md
@@ -99,10 +99,10 @@ This Flink Streaming Agent evaluates each enriched application plus payment hist
       m.credit_score,
       m.credit_utilization,
       m.debt_to_income_ratio,
-      CAST(JSON_VALUE(agent_result.response, '$.fraud_risk_score') AS DOUBLE) AS fraud_risk_score,
-      JSON_VALUE(agent_result.response, '$.loan_stack_risk') AS loan_stack_risk,
-      JSON_VALUE(agent_result.response, '$.risk_category') AS risk_category,
-      JSON_VALUE(agent_result.response, '$.agent_reasoning') AS agent_reasoning,
+      CAST(JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.fraud_risk_score') AS DOUBLE) AS fraud_risk_score,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.loan_stack_risk') AS loan_stack_risk,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.risk_category') AS risk_category,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.agent_reasoning') AS agent_reasoning,
       m.application_ts
       FROM enriched_mortgage_with_payments m,
       LATERAL TABLE(
@@ -192,10 +192,10 @@ Built on **Confluent Cloud Streaming Agents**, AI agents run natively in Flink S
       m.borrower_name,
       m.property_state,
       m.loan_amount,
-      JSON_VALUE(agent_result.response, '$.final_interest_rate') AS final_interest_rate,
-      JSON_VALUE(agent_result.response, '$.decision') AS decision,
-      JSON_VALUE(agent_result.response, '$.explanation') AS explanation,
-      JSON_VALUE(agent_result.response, '$.letter_body') AS letter_body,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.final_interest_rate') AS final_interest_rate,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.decision') AS decision,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.explanation') AS explanation,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.letter_body') AS letter_body,
       m.application_ts AS `timestamp`
    FROM mortgage_validated_apps m,
    LATERAL TABLE(
@@ -321,10 +321,10 @@ Built on **Confluent Cloud Streaming Agents**, AI agents run natively in Flink S
       m.borrower_name,
       m.property_state,
       m.loan_amount,
-      JSON_VALUE(agent_result.response, '$.final_interest_rate') AS final_interest_rate,
-      JSON_VALUE(agent_result.response, '$.decision') AS decision,
-      JSON_VALUE(agent_result.response, '$.explanation') AS explanation,
-      JSON_VALUE(agent_result.response, '$.letter_body') AS letter_body,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.final_interest_rate') AS final_interest_rate,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.decision') AS decision,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.explanation') AS explanation,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.letter_body') AS letter_body,
       m.application_ts AS `timestamp`
    FROM mortgage_validated_apps m,
    LATERAL TABLE(

--- a/terraform/modules/flink-statements/main.tf
+++ b/terraform/modules/flink-statements/main.tf
@@ -370,10 +370,10 @@ resource "confluent_flink_statement" "mortgage_validated_apps" {
       m.credit_score,
       m.credit_utilization,
       m.debt_to_income_ratio,
-      CAST(JSON_VALUE(agent_result.response, '$.fraud_risk_score') AS DOUBLE) AS fraud_risk_score,
-      JSON_VALUE(agent_result.response, '$.loan_stack_risk') AS loan_stack_risk,
-      JSON_VALUE(agent_result.response, '$.risk_category') AS risk_category,
-      JSON_VALUE(agent_result.response, '$.agent_reasoning') AS agent_reasoning,
+      CAST(JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.fraud_risk_score') AS DOUBLE) AS fraud_risk_score,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.loan_stack_risk') AS loan_stack_risk,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.risk_category') AS risk_category,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.agent_reasoning') AS agent_reasoning,
       m.application_ts
     FROM `${var.environment_display_name}`.`${var.kafka_cluster_display_name}`.`enriched_mortgage_with_payments` m,
     LATERAL TABLE(
@@ -538,10 +538,10 @@ resource "confluent_flink_statement" "mortgage_decisions" {
       m.borrower_name,
       m.property_state,
       m.loan_amount,
-      JSON_VALUE(agent_result.response, '$.final_interest_rate') AS final_interest_rate,
-      JSON_VALUE(agent_result.response, '$.decision') AS decision,
-      JSON_VALUE(agent_result.response, '$.explanation') AS explanation,
-      JSON_VALUE(agent_result.response, '$.letter_body') AS letter_body,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.final_interest_rate') AS final_interest_rate,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.decision') AS decision,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.explanation') AS explanation,
+      JSON_VALUE(REGEXP_REPLACE(agent_result.response, '```(json)?|```', ''), '$.letter_body') AS letter_body,
       m.application_ts AS `timestamp`
     FROM `${var.environment_display_name}`.`${var.kafka_cluster_display_name}`.`mortgage_validated_apps` m,
     LATERAL TABLE(


### PR DESCRIPTION
## Summary
After switching to Claude Sonnet 4.5 (#47), both Streaming Agents wrap their JSON responses in markdown code fences (` ```json ... ``` `) despite the prompt explicitly forbidding it. This causes every `JSON_VALUE` extract on `agent_result.response` to return NULL, so all downstream agent fields (`fraud_risk_score`, `risk_category`, `decision`, `letter_body`, etc.) end up NULL in `mortgage_validated_apps` and `mortgage_decisions`.

Fix: wrap `agent_result.response` in `REGEXP_REPLACE(..., '` ` `(json)?|` ` `', '')` before `JSON_VALUE` to strip the fences. Applied in:
- `lab2/lab2-README.md` — Agent 1 CTAS, Agent 2 CTAS, and the Agent 2 troubleshooting query
- `terraform/modules/flink-statements/main.tf` — both agent CTAS used by demo mode

## Test plan
- [x] Confirmed Sonnet wraps response in markdown fences (verified by querying raw `agent_result.response`)
- [x] `REGEXP_REPLACE` strip resolves NULL `JSON_VALUE` outputs in workshop deployment
- [ ] Demo mode end-to-end deploy verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)