### PR TITLE
fix: revert to Opus 4.5 and improve agent decision prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Pure Confluent Cloud infrastructure — no datagen, no CDC connector:
 - Topics (all 1 partition): `mortgage_applications`, `payment_history`, `incomplete_mortgage_applications` (DLQ), `PROD.public.applicant_credit_score` (pre-created with `cleanup.policy=compact`)
 - AVRO schemas with data quality rules (CEL validation: payslip URI must match `^s3://riverbank-payslip-bucket/[a-zA-Z0-9._/-]+$` → DLQ routing on failure)
 - `alter_mortgage_applications` Flink statement — adds WATERMARK on `application_ts` for temporal join support
-- Bedrock connection + LLM model (`llm_textgen_model` — Claude Sonnet 4.5, 50K max tokens)
+- Bedrock connection + LLM model (`llm_textgen_model` — Claude Opus 4.5, 50K max tokens)
 - MCP connection (configurable endpoint + transport type) for external tool access
 - Webapp Docker container (`mortgage-webapp`) — built locally from `webapp/Dockerfile`, port 5001→5000
 - Outputs credentials for datagen and CDC connector modules

--- a/SETUP-SELF-SERVE.md
+++ b/SETUP-SELF-SERVE.md
@@ -63,13 +63,13 @@ Before starting, make sure you have:
 > Request model access before you begin the Terraform steps below. Approval can take a few minutes, and starting early avoids delays later.
 
 <details>
-<summary>Enable Claude Sonnet 4.5 in Amazon Bedrock</summary>
+<summary>Enable Claude Opus 4.5 in Amazon Bedrock</summary>
 
-To enable Claude Sonnet 4.5 in your AWS account via Amazon Bedrock:
+To enable Claude Opus 4.5 in your AWS account via Amazon Bedrock:
 
 1. Open the Amazon Bedrock Console (`https://console.aws.amazon.com/bedrock/home?/overview`) and ensure you are in the same region you will deploy.
 2. In the left sidebar, under Bedrock configuration, click Model access.
-3. Locate Claude Sonnet 4.5 in the list of available models.
+3. Locate Claude Opus 4.5 in the list of available models.
 4. Click Available to request, then select Request model access.
 5. In the request wizard, click Next and follow the prompts to complete the request.
 

--- a/lab2/lab2-README.md
+++ b/lab2/lab2-README.md
@@ -296,6 +296,8 @@ Built on **Confluent Cloud Streaming Agents**, AI agents run natively in Flink S
          '- Subject: Mortgage Decision - Application ', m.application_id, ' - ', m.borrower_name, '\n',
          '- Body: Use the exact letter_body value from your JSON output\n\n',
          
+         'CRITICAL: After calling gmail_send_email, your FINAL response (the very last thing you output) MUST be the same raw JSON object you constructed. Do NOT respond with "Email sent" or any acknowledgment. Re-emit the complete JSON object as your final answer. The system extracts fields from your final response, so it must be the JSON.\n\n',
+
          'REMEMBER: Output ONLY the JSON object. Do NOT include email fields in the JSON. Do NOT add any text before or after the JSON.'
       ),
          m.application_id,
@@ -425,6 +427,8 @@ Built on **Confluent Cloud Streaming Agents**, AI agents run natively in Flink S
          '- Subject: Mortgage Decision - Application ', m.application_id, ' - ', m.borrower_name, '\n',
          '- Body: Use the exact letter_body value from your JSON output\n\n',
          
+         'CRITICAL: After calling gmail_send_email, your FINAL response (the very last thing you output) MUST be the same raw JSON object you constructed. Do NOT respond with "Email sent" or any acknowledgment. Re-emit the complete JSON object as your final answer. The system extracts fields from your final response, so it must be the JSON.\n\n',
+
          'REMEMBER: Output ONLY the JSON object. Do NOT include email fields in the JSON. Do NOT add any text before or after the JSON.'
       ),
          m.application_id,

--- a/lab2/lab2-README.md
+++ b/lab2/lab2-README.md
@@ -256,7 +256,7 @@ Built on **Confluent Cloud Streaming Agents**, AI agents run natively in Flink S
          '{\n'
          '"letter_body": (string) acceptace or rejection letter\n',
          '"decision": (enum) Either "Approved" or "Rejected"\n',
-         '"final_interest_rate": (float) The suggested interest rate for the applicant if the application "decision" is Approved. If the application "decision" is "Rejected" suggest "-1" interest rate.  \n',
+         '"final_interest_rate": (string) The suggested interest rate as a string (e.g., "7.5"). For Rejected applications use "-1.0". Never use null.\n',
          '"explanation": (string) A brief narrative explaining the decision and interest rate logic\n',
          '}',
          'Provide only the JSON.\n\n',
@@ -264,7 +264,7 @@ Built on **Confluent Cloud Streaming Agents**, AI agents run natively in Flink S
          
          '## Field Requirements\n',
          '- decision: Must be exactly "Approved" or "Rejected"\n',
-         '- final_interest_rate: Must be a STRING (e.g., "7.5" not 7.5). Use "-1.0" for rejected applications\n',
+         '- final_interest_rate: Must be a STRING (e.g., "7.5" not 7.5). Use "-1.0" for rejected applications. Never null.\n',
          '- explanation: Single string with brief reasoning\n',
          '- letter_body: Single string containing the complete letter (see template below)\n\n',
          
@@ -387,7 +387,7 @@ Built on **Confluent Cloud Streaming Agents**, AI agents run natively in Flink S
          '{\n'
          '"letter_body": (string) acceptace or rejection letter\n',
          '"decision": (enum) Either "Approved" or "Rejected"\n',
-         '"final_interest_rate": (float) The suggested interest rate for the applicant if the application "decision" is Approved. If the application "decision" is "Rejected" suggest "-1" interest rate.  \n',
+         '"final_interest_rate": (string) The suggested interest rate as a string (e.g., "7.5"). For Rejected applications use "-1.0". Never use null.\n',
          '"explanation": (string) A brief narrative explaining the decision and interest rate logic\n',
          '}',
          'Provide only the JSON.\n\n',
@@ -395,7 +395,7 @@ Built on **Confluent Cloud Streaming Agents**, AI agents run natively in Flink S
          
          '## Field Requirements\n',
          '- decision: Must be exactly "Approved" or "Rejected"\n',
-         '- final_interest_rate: Must be a STRING (e.g., "7.5" not 7.5). Use "-1.0" for rejected applications\n',
+         '- final_interest_rate: Must be a STRING (e.g., "7.5" not 7.5). Use "-1.0" for rejected applications. Never null.\n',
          '- explanation: Single string with brief reasoning\n',
          '- letter_body: Single string containing the complete letter (see template below)\n\n',
          

--- a/terraform/modules/base/main.tf
+++ b/terraform/modules/base/main.tf
@@ -381,7 +381,7 @@ resource "confluent_flink_connection" "bedrock_connection" {
 
   display_name   = "llm-textgen-connection"
   type           = "BEDROCK"
-  endpoint       = "https://bedrock-runtime.${var.cloud_region}.amazonaws.com/model/${local.model_prefix}.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke"
+  endpoint       = "https://bedrock-runtime.${var.cloud_region}.amazonaws.com/model/${local.model_prefix}.anthropic.claude-opus-4-5-20251101-v1:0/invoke"
   aws_access_key = var.bedrock_access_key
   aws_secret_key = var.bedrock_secret_key
 

--- a/terraform/modules/flink-statements/main.tf
+++ b/terraform/modules/flink-statements/main.tf
@@ -642,6 +642,8 @@ resource "confluent_flink_statement" "mortgage_decisions" {
           '- Subject: Mortgage Decision - Application ', m.application_id, ' - ', m.borrower_name, '\n',
           '- Body: Use the exact letter_body value from your JSON output\n\n',
 
+          'CRITICAL: After calling gmail_send_email, your FINAL response (the very last thing you output) MUST be the same raw JSON object you constructed. Do NOT respond with "Email sent" or any acknowledgment. Re-emit the complete JSON object as your final answer. The system extracts fields from your final response, so it must be the JSON.\n\n',
+
           'REMEMBER: Output ONLY the JSON object. Do NOT include email fields in the JSON. Do NOT add any text before or after the JSON.'
         ),
         m.application_id,

--- a/terraform/modules/flink-statements/main.tf
+++ b/terraform/modules/flink-statements/main.tf
@@ -602,7 +602,7 @@ resource "confluent_flink_statement" "mortgage_decisions" {
           '{\n'
           '"letter_body": (string) acceptace or rejection letter\n',
           '"decision": (enum) Either "Approved" or "Rejected"\n',
-          '"final_interest_rate": (float) The suggested interest rate for the applicant if the application "decision" is Approved. If the application "decision" is "Rejected" suggest "-1" interest rate.  \n',
+          '"final_interest_rate": (string) The suggested interest rate as a string (e.g., "7.5"). For Rejected applications use "-1.0". Never use null.\n',
           '"explanation": (string) A brief narrative explaining the decision and interest rate logic\n',
           '}',
           'Provide only the JSON.\n\n',
@@ -610,7 +610,7 @@ resource "confluent_flink_statement" "mortgage_decisions" {
 
           '## Field Requirements\n',
           '- decision: Must be exactly "Approved" or "Rejected"\n',
-          '- final_interest_rate: Must be a STRING (e.g., "7.5" not 7.5). Use "-1.0" for rejected applications\n',
+          '- final_interest_rate: Must be a STRING (e.g., "7.5" not 7.5). Use "-1.0" for rejected applications. Never null.\n',
           '- explanation: Single string with brief reasoning\n',
           '- letter_body: Single string containing the complete letter (see template below)\n\n',
 


### PR DESCRIPTION
## Summary

Three changes to make the lab2 / demo-mode mortgage decisions workflow reliable end-to-end:

### 1. Revert Bedrock model from Sonnet 4.5 to Opus 4.5 (reverts #47)
Sonnet 4.5 broke lab2 in two ways Opus 4.5 doesn't:
- Wraps JSON responses in ` ```json ... ``` ` despite the prompt explicitly forbidding it, causing every `JSON_VALUE` extract to return NULL
- The `mortgage_decisions_agent` (which uses the `gmail_send_email` tool) drops into chatbot mode and asks for clarification instead of executing the tool, exhausting `MAX_ITERATIONS` and producing `Final response was null when transitioning to FINAL_ANSWER state` errors

### 2. Require agent to re-emit JSON after `gmail_send_email` tool call
Even on Opus, the agent occasionally returned an acknowledgment ("Email sent") as its final response after invoking `gmail_send_email`, instead of re-emitting the JSON object. When that happened, `JSON_VALUE` returned NULL for `decision`/`explanation`/`final_interest_rate`/`letter_body` — even though the email was delivered correctly. Most reproducible on the Rejected path. Added an explicit `CRITICAL:` instruction requiring the final response to be the same raw JSON object after any tool call.

### 3. Make `final_interest_rate` consistently a string in the prompt
The prompt described the field as `(float)` in the JSON schema example but as `Must be a STRING` in the Field Requirements section a few lines later. Faced with this contradiction on the Rejected path, Opus emitted JSON `null` instead of either form. Made both descriptions agree on string type, explicitly forbid `null`, and require `"-1.0"` for rejected applications.

Applied in `lab2/lab2-README.md` (main CTAS + troubleshooting query) and `terraform/modules/flink-statements/main.tf` (demo mode CTAS).

## Test plan
- [x] Workshop deploy with Opus 4.5 — full agent 1 + agent 2 + email flow works end-to-end
- [x] `mortgage_validated_apps` row populated with risk fields
- [x] `mortgage_decisions` row populated for Approved (John Doe) and Rejected (Omar Soli) paths
- [x] Email delivery verified for both paths
- [x] `final_interest_rate` populated as string (`"-1.0"` for rejected) instead of NULL
- [ ] Demo mode redeploy verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)